### PR TITLE
Remove hardcoded file paths

### DIFF
--- a/Application/Generator/generator.py
+++ b/Application/Generator/generator.py
@@ -799,14 +799,14 @@ class Generator(QWidget):
         tcl_vivado_code = tcl_file_template.replace("$tcl_path", self.tcl_path)
         tcl_vivado_code = tcl_vivado_code.replace("$comp_name", comp)
         mainPackagePath = "add_files -norecurse  "
-        mainPackagePath = mainPackagePath + ProjectManager.get_main_vhd()
+        mainPackagePath = mainPackagePath + ProjectManager.get_package_vhd()
         mainPackagePath = mainPackagePath.replace("\\", "/")
         if lang == "VHDL":
             tcl_vivado_code = tcl_vivado_code.replace("$arrayPackage", mainPackagePath)
         else:
             tcl_vivado_code = tcl_vivado_code.replace("$arrayPackage", "")
         files = ""
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
         hdlDesign = HDLGen.getElementsByTagName("hdlDesign")
@@ -899,7 +899,7 @@ class Generator(QWidget):
         wd = os.getcwd()
         wd = wd.replace("\\", "/")
         mainPackagePath = "add_files -norecurse  "  # + wd
-        mainPackagePath = mainPackagePath + ProjectManager.get_main_vhd()
+        mainPackagePath = mainPackagePath + ProjectManager.get_package_vhd()
         mainPackagePath = mainPackagePath.replace("\\", "/")
         # if self.includeArrays == True:
         # tcl_quartus_code = tcl_quartus_code.replace("$arrayPackage", mainPackagePath)
@@ -907,7 +907,7 @@ class Generator(QWidget):
         # tcl_quartus_code = tcl_quartus_code.replace("$arrayPackage","")
         files = ""
         # mainPackageDir = os.getcwd() + "\HDLDesigner\Package\mainPackage.hdlgen"
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
         hdlDesign = HDLGen.getElementsByTagName("hdlDesign")
@@ -1429,7 +1429,7 @@ class Generator(QWidget):
         # Parsing the xml file
         vhdl_database = minidom.parse(vhdl_database_path)
         vhdl_root = vhdl_database.documentElement
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
         hdlDesign = HDLGen.getElementsByTagName("hdlDesign")
@@ -1473,7 +1473,7 @@ class Generator(QWidget):
         array_vhdl_code = array_vhdl_code.replace("$arrays", gen_arrays)
 
         array_vhdl_code = array_vhdl_code.replace("$Component", comp)
-        array_vhdl_file_path = ProjectManager.get_main_vhd()
+        array_vhdl_file_path = ProjectManager.get_package_vhd()
         # Write array code to file
         with open(array_vhdl_file_path, "w") as f:
             f.write(array_vhdl_code)
@@ -1522,7 +1522,7 @@ class Generator(QWidget):
         internalnames = []
         instances = []
         stateTypeSig = False
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
         hdlDesign = HDLGen.getElementsByTagName("hdlDesign")
@@ -2381,7 +2381,7 @@ class Generator(QWidget):
         header_node = hdl_design[0].getElementsByTagName("header")
         comp_node = header_node[0].getElementsByTagName("compName")[0]
         entity_name = comp_node.firstChild.data
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
         hdlDesign = HDLGen.getElementsByTagName("hdlDesign")

--- a/Application/HDLDesigner/Architecture/instance_dialog.py
+++ b/Application/HDLDesigner/Architecture/instance_dialog.py
@@ -287,7 +287,7 @@ class InstanceDialog(QDialog):
     def load_data(self):
         self.comps = []
         self.comps_names = []
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
         hdlDesign = HDLGen.getElementsByTagName("hdlDesign")

--- a/Application/HDLDesigner/IOPorts/io_port_dialog.py
+++ b/Application/HDLDesigner/IOPorts/io_port_dialog.py
@@ -110,7 +110,7 @@ class IOPortDialog(QDialog):
         self.cancelled = True
         self.arrays=[]
         self.setup_ui()
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
         hdlDesign = HDLGen.getElementsByTagName("hdlDesign")

--- a/Application/HDLDesigner/InternalSignal/int_sig_dialog.py
+++ b/Application/HDLDesigner/InternalSignal/int_sig_dialog.py
@@ -187,7 +187,7 @@ class IntSignalDialog(QDialog):
         self.cancelled = True
         self.arrays = []
         self.setup_ui()
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
 
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement

--- a/Application/HDLDesigner/Package/package.py
+++ b/Application/HDLDesigner/Package/package.py
@@ -208,7 +208,7 @@ class Package(QWidget):
             self.save_data()
 
     def save_data(self):
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         root = minidom.parse(mainPackageDir)
 
         HDLGen = root.documentElement
@@ -255,7 +255,7 @@ class Package(QWidget):
                 self.package_table.removeRow(0)
                 self.arrays.pop(0)
                 self.arrays_names.pop(0)
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         try:
             root = minidom.parse(mainPackageDir)
             HDLGen = root.documentElement

--- a/Application/HDLDesigner/Subcomponents/subcomponents.py
+++ b/Application/HDLDesigner/Subcomponents/subcomponents.py
@@ -183,7 +183,7 @@ class Subcomponents(QWidget):
             self.comps_names.pop(row)
             self.save_data()
     def save_data(self):
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
 
         root = minidom.parse(mainPackageDir)
         HDLGen = root.documentElement
@@ -222,7 +222,7 @@ class Subcomponents(QWidget):
                 self.component_table.removeRow(0)
                 self.comps.pop(0)
                 self.comps_names.pop(0)
-        mainPackageDir = ProjectManager.get_main_hdlgen()
+        mainPackageDir = ProjectManager.get_package_hdlgen()
         try:
             root = minidom.parse(mainPackageDir)
             HDLGen = root.documentElement

--- a/Application/ProjectManager/project_manager.py
+++ b/Application/ProjectManager/project_manager.py
@@ -3,8 +3,8 @@
 import os
 from xml.dom import minidom
 from pathlib import Path
-from PySide2.QtWidgets import *
-from PySide2.QtGui import *
+from PySide2.QtWidgets import QWidget, QLabel, QPushButton, QGridLayout, QLineEdit, QRadioButton, QCheckBox, QComboBox, QHBoxLayout, QVBoxLayout, QFrame, QMessageBox, QFileDialog
+from PySide2.QtGui import QFont, Qt
 import qtawesome as qta
 import configparser
 import webbrowser
@@ -422,7 +422,7 @@ class ProjectManager(QWidget):
             ProjectManager.proj_enviro = ProjectManager.proj_enviro.replace("\\", "/")
             ProjectManager.xml_data_path = self.proj_dir + self.proj_name + "/" + "HDLGenPrj" + "/" + self.proj_name + ".hdlgen"
             ProjectManager.xml_data_path = ProjectManager.xml_data_path.replace("\\", "/")
-            ProjectManager.package_xml_data_path = self.proj_enviro + "\Package\mainPackage.hdlgen"
+            ProjectManager.package_xml_data_path = ProjectManager.get_package_hdlgen();
             ProjectManager.package_xml_data_path = ProjectManager.package_xml_data_path.replace("\\", "/")
 
     def proj_folder_change(self):
@@ -493,11 +493,11 @@ class ProjectManager(QWidget):
         return ProjectManager.proj_enviro
     
     @staticmethod
-    def get_main_hdlgen():
+    def get_package_hdlgen():
         return os.path.join(ProjectManager.proj_enviro, "Package", "mainPackage.hdlgen")
     
     @staticmethod
-    def get_main_vhd():
+    def get_package_vhd():
         return os.path.join(ProjectManager.proj_enviro, "Package", "MainPackage.vhd")
     
     def set_proj_environment(self):
@@ -770,10 +770,10 @@ class ProjectManager(QWidget):
                 f.write(xml_str)
 
         ProjectManager.xml_data_path = ProjectManager.proj_dir + ProjectManager.proj_name + "/" + "HDLGenPrj" + "/" + ProjectManager.proj_name + ".hdlgen"
-        ProjectManager.package_xml_data_path = ProjectManager.proj_enviro + "\Package\mainPackage.hdlgen"
+        ProjectManager.package_xml_data_path = ProjectManager.get_package_hdlgen()
         if not os.path.exists(ProjectManager.package_xml_data_path):
-            if not os.path.exists(ProjectManager.proj_enviro + "\Package\\"):
-                os.makedirs(ProjectManager.proj_enviro + "\Package\\")
+            if not os.path.exists(os.path.join(ProjectManager.proj_enviro, "Package")):
+                os.makedirs(os.path.join(ProjectManager.proj_enviro, "Package"))
             # converting the doc into a string in xml format
             package_xml_str = rootPack.toprettyxml(indent="\t")
             with open(ProjectManager.package_xml_data_path, "w") as f:

--- a/Application/config.ini
+++ b/Application/config.ini
@@ -3,7 +3,7 @@ author = Fearghal Morgan
 email = fearghal.morgan1@gmail.com
 company = University of Galway
 vivado.bat = C:/Xilinx/Vivado/2019.1/bin/vivado.bat
-recentenviro = C:/2023/HDLGenTop/myFiles/HDLGen-ChatGPT/User_Projects
+recentenviro = /home/crash/HDLGen-ChatGPT/User_Projects
 quartus = C:/intelFPGA_lite/22.1std/quartus/bin64/quartus.exe
 vhdlchatgptmodel = 
 	~ Notes START ===============
@@ -84,14 +84,14 @@ vhdlchatgptmodel =
 	~ Example: addOut <= std_logic_vector (unsigned(addin1) + unsigned(addIn0) );
 	~  Uses A.3 function "+" ( L,R: UNSIGNED) return UNSIGNED
 	~  Adds two std_logic_vector (slv) signals. Convert (type cast) slv signals to unsigned type, perform +, and then type cast the unsigned result to std_logic_vector type
-
-	The following example is unnecessarilu complicated. 
-	sourceDByte <= BRAM_dOut(to_integer(unsigned(CSXAdd) + 7) downto to_integer(unsigned(CSXAdd)));, 
+	
+	The following example is unnecessarilu complicated.
+	sourceDByte <= BRAM_dOut(to_integer(unsigned(CSXAdd) + 7) downto to_integer(unsigned(CSXAdd)));,
 	where sourceDByte and BRAM_dOut are type std_logic_vector, and signal CSXAdd is type integer.
 	The assignment should be sourceDByte <= BRAM_dOut(8*CSXAdd+7 downto CSXAdd );.
 	It is not necessary to convert CSXAdd integer type to integer using to_integer(unsigned(CSXAdd).
 	Apply this rule when generating VHDL.
-
+	
 	Do not unnecessarily convert integer type signals to unsigned type and then integer type.
 	
 	If an assignment includes a std_logic_vector signal as an array index, convert the signal to an integer index using "ieee.numeric_std" package to_integer(unsigned()).
@@ -151,7 +151,7 @@ vhdlchatgptmodel =
 	In all VHDL processes, replace each conditional when else statement with a case statement or an if statement, without removing any signal state check, and not including any assignments which duplicate the assignment labelled '-- Default assignment'
 	~ Conditional statements are supported in IEEE VHDL-2008 though not all EDA tools support VHDL-2008, so do not allow conditional statements
 	~ ChatGPT does not always follow this prompt, so it may be necessary to submit this prompt again, after the ChatGPT run.
-
+	
 	For signal which have a digit boundary width, use hexadecimal format in constant assignments, with 'x' prefix before double quotation marks.
 vhdlchatgpttestbench = 
 	~ Notes START ===============
@@ -185,27 +185,27 @@ vhdlchatgpttestbench =
 	Column 2: delay
 	Other:    Note
 	Rows 6 onwards includes columns with values: TestNo, delay, input signal values, expected output signal values, Note
-
+	
 	Output a single formatted code box, including the following:
 	~List all input signal names in the code box, as a VHDL comment.
 	~List all output signal names in the code box, as a VHDL comment.
-
+	
 	Output a single VHDL process labelled stim_p, including the following elements (1-10), for each TestNo, though not including a for loop
 	1. Do not include a for loop
 	2. Do not include library declaration section, entity declaration section, architecture declaration section, signal declarations, or line which includes begin
-	3. Do not include any signal declarations, or stim_p: process lines  
+	3. Do not include any signal declarations, or stim_p: process lines
 	4. Signal TestNo, using TestNo <= integer assignment.
 	5. Note column field, as a VHDL comment.
 	6. Only for input signals: assign each input signal to the value in its corresponding signal column, never omitting the signal value radix prefix, e,g, x prefix before the double quotation marks for hexadecimal format, b prefix before the double quotation marks for binary format. Do not assign any output signal values.
 	7. Delay statement, format 'wait for (delay * period);', where delay is an integer or real value, never 0, placing the delay statement after all of the signal stimulus for the TestNo have been assigned, and always including brackets around the delay statement.
 	8. Perform the following points a. to c.
 	a. Compare each output signal with its corresponding value in the output signal column
-	b. Output a separate VHDL assert/report statement for each output signal, with a warning message if the test fails, 
-		not including the keyword 'image or the symbol '&' or 'assertion'.
+	b. Output a separate VHDL assert/report statement for each output signal, with a warning message if the test fails,
+	not including the keyword 'image or the symbol '&' or 'assertion'.
 	c. Do not test any input signals.
 	9. Do not include 'wait;'
 	10. Do not include 'end process' line
-
+	
 	For signal which have a digit boundary width, use hexadecimal format in constant assignments, with 'x' prefix before double quotation marks.
 	
 	Do not include a separate process for each TestNo.
@@ -223,7 +223,7 @@ vhdlchatgpttestbench =
 	Do not request that I '-- Continue with the remaining test cases...'. Please output code for all of the tests.
 	Do not request that I '-- Repeat similar sections for the remaining tests...'. Please output code for all of the tests.
 	Do not request that I '-- Comparison of output signals with expected values...'. Please output code for all of the tests.
-	Do not request that I '-- Continue similar sections for the remaining tests...'. Please output code for all of the tests.	
+	Do not request that I '-- Continue similar sections for the remaining tests...'. Please output code for all of the tests.
 	Ensure that 'x' prefix is included before all hexadecimal signal value double quotation marks.
 verilogchatgptmodel = 
 	~ Notes START ===============
@@ -321,7 +321,7 @@ verilogchatgpttestbench =
 	~ FM Not currently used
 	~ If the table includes a TAB, output message "Table includes TABs" and stop
 	~ If the table does not include a TAB, continue.
-
+	
 	~ Define the table structure. The Test Table (excluding the header section) is pasted in the Test Table UI.
 	The format of the table is as follows
 	Row 1 includes input signal name headings
@@ -333,21 +333,21 @@ verilogchatgpttestbench =
 	Column 2: delay
 	Other:    Note
 	Rows 6 onwards includes columns with values: TestNo, delay, input signal values, expected output signal values, Note
-
+	
 	Output a single formatted code box, including the following:
 	List all input signal names in the code box, as a Verilog comment.
 	List all output signal names in the code box, as a Verilog comment.
-
+	
 	Output a single Verilog process labelled stim_p, including the following elements (1-5), for each TestNo, though not including a for loop
 	1. Integer signal TestNo assignment.
 	2. Note column field, as a Verilog comment.
 	3. Only for input signals: assign each input signal to the value in its corresponding signal column, using the corresponding signal radix in the assignment. Do not assign any output signal values.
 	4. Delay statement, format '# (delay * period);', where delay is an integer or real value, never 0, placing the delay statement after all of the signal stimulus for the TestNo have been assigned, and always including brackets around the delay statement.
-	5. Perform the following points a. to d. 
-	   a. Compare each output signal with its corresponding value in the output signal column
-	   b. Output a separate warning message for each signal, if a test fails. 
-	   c. Include TestNo and signal value in the message
-  	   d. Do not test any input signals. 
+	5. Perform the following points a. to d.
+	a. Compare each output signal with its corresponding value in the output signal column
+	b. Output a separate warning message for each signal, if a test fails.
+	c. Include TestNo and signal value in the message
+	d. Do not test any input signals.
 	
 	~ FM review
 	For all input signals, ensure use of the correct values and the correct signal widths.
@@ -535,25 +535,25 @@ vhdlchatgpttestbenchreset =
 	Column 2: delay
 	Other:    Note
 	Rows 6 onwards includes columns with values: TestNo, delay, input signal values, expected output signal values, Note
-
+	
 	Output a single formatted code box, including the following:
 	~List all input signal names in the code box, as a VHDL comment.
 	~List all output signal names in the code box, as a VHDL comment.
-
+	
 	Output a single VHDL process labelled stim_p, including the following elements (1-7), for each TestNo, though not including a for loop
 	1. Omit (from the code box) lines which include stim_p: process or begin
 	2. Integer signal TestNo, using TestNo <= assignment.
 	3. Note column field, as a VHDL comment.
 	4. Only for input signals: assign each input signal (omitting no input signals) to the value in its corresponding 'input' column, using the corresponding signal radix in the assignment. Do not assign any output signal values.
 	5. Delay statement, format 'wait for (delay * period);', where delay is an integer or real value, never 0, placing the delay statement after all of the signal stimulus for the TestNo have been assigned, and always including brackets around the delay statement.
-	6. Perform the following points a. to d. 
-	   a. Compare each output signal with its corresponding value in the output signal column
-	   b. Output a separate VHDL report statement for each signal, with a warning message if the test fails. 
-	   c. Include TestNo and signal value in the message, in the following format: 
- 		  assert output signal = signal value (using signal radix) report "TestNo " TestNo output signal " mismatch" severity warning;
-  	   d. Do not test any input signals. 
-	7. Omit (from the code box) lines which include wait; or end process stim_p; 
-
+	6. Perform the following points a. to d.
+	a. Compare each output signal with its corresponding value in the output signal column
+	b. Output a separate VHDL report statement for each signal, with a warning message if the test fails.
+	c. Include TestNo and signal value in the message, in the following format:
+	assert output signal = signal value (using signal radix) report "TestNo " TestNo output signal " mismatch" severity warning;
+	d. Do not test any input signals.
+	7. Omit (from the code box) lines which include wait; or end process stim_p;
+	
 	For signal which have a digit boundary width, use hexadecimal format in constant assignments, with 'x' prefix before double quotation marks.
 	
 	Do not include a separate process for each TestNo.
@@ -571,7 +571,7 @@ vhdlchatgpttestbenchreset =
 	Do not request that I '-- Continue with the remaining test cases...'. Please output code for all of the tests.
 	Do not request that I '-- Repeat similar sections for the remaining tests...'. Please output code for all of the tests.
 	Do not request that I '-- Comparison of output signals with expected values...'. Please output code for all of the tests.
-	Do not request that I '-- Continue similar sections for the remaining tests...'. Please output code for all of the tests.	
+	Do not request that I '-- Continue similar sections for the remaining tests...'. Please output code for all of the tests.
 verilogchatgptmodelreset = 
 	~ Notes START ===============
 	~ "~" is comment line prefix
@@ -668,7 +668,7 @@ verilogchatgpttestbenchreset =
 	~ FM Not currently used
 	~ If the table includes a TAB, output message "Table includes TABs" and stop
 	~ If the table does not include a TAB, continue.
-
+	
 	~ Define the table structure. The Test Table (excluding the header section) is pasted in the Test Table UI.
 	The format of the table is as follows
 	Row 1 includes input signal name headings
@@ -680,21 +680,21 @@ verilogchatgpttestbenchreset =
 	Column 2: delay
 	Other:    Note
 	Rows 6 onwards includes columns with values: TestNo, delay, input signal values, expected output signal values, Note
-
+	
 	Output a single formatted code box, including the following:
 	List all input signal names in the code box, as a Verilog comment.
 	List all output signal names in the code box, as a Verilog comment.
-
+	
 	Output a single Verilog process labelled stim_p, including the following elements (1-5), for each TestNo, though not including a for loop
 	1. Integer signal TestNo assignment.
 	2. Note column field, as a Verilog comment.
 	3. Only for input signals: assign each input signal (omitting no input signals) to the value in its corresponding 'input' column, using the corresponding signal radix in the assignment. Do not assign any output signal values.
 	4. Delay statement, format '# (delay * period);', where delay is an integer or real value, never 0, placing the delay statement after all of the signal stimulus for the TestNo have been assigned, and always including brackets around the delay statement.
-	5. Perform the following points a. to d. 
-	   a. Compare each output signal with its corresponding value in the output signal column
-	   b. Output a separate warning message for each signal, if a test fails. 
-	   c. Include TestNo and signal value in the message
-  	   d. Do not test any input signals. 
+	5. Perform the following points a. to d.
+	a. Compare each output signal with its corresponding value in the output signal column
+	b. Output a separate warning message for each signal, if a test fails.
+	c. Include TestNo and signal value in the message
+	d. Do not test any input signals.
 	
 	~ FM review
 	For all input signals, ensure use of the correct values and the correct signal widths.
@@ -709,3 +709,4 @@ verilogchatgpttestbenchreset =
 	Do not request that I '-- Repeat similar sections for the remaining tests...'. Please output code for all of the tests.
 	Do not request that I '-- Comparison of output signals with expected values...'. Please output code for all of the tests.
 	Do not request that I '-- Continue similar sections for the remaining tests...'. Please output code for all of the tests.
+


### PR DESCRIPTION
This fix removes hardcoded Windows-style file paths which arose from manually appending to paths using string concatenation.

To resolve the issue, these instances of string concatenation have been replaced as appropriate with calls to `get_package_hdlgen()` and `os.path.join(..., "Package")`.

Closes #50 .